### PR TITLE
Add blacklist option for RequestLog::Middleware

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -49,18 +49,28 @@ Now setup the Middleware in your config.ru file:
 
   use RequestLog::Middleware
 
-Here is an example of how you can customize the middleware:
-
-  use RequestLog::Middleware,
-	  :logger => lambda { |data| RequestLog::Db.requests.insert(data.attributes.except(:runtime)) },
-	  :timeout => 0.5
-
 In order to use the Rake tasks you need to make sure you have the MongoDB connection setup and that you
 require the tasks in your Rakefile, like this:
 
   require 'request_log'
   require 'config/initializers/request_log.rb' # The file where you setup the mongo db connection
   require 'request_log/tasks'
+
+== Customizing the middleware
+
+Here is an example of how you can customize the middleware:
+
+  use RequestLog::Middleware,
+	  :logger => lambda { |data| RequestLog::Db.requests.insert(data.attributes.except(:runtime)) },
+	  :timeout => 0.5
+
+Here are available options RequestLog::Middleware will respect:
+
+  options[:logger]    - set a custom lambda determining which data attributes are logged
+  options[:profiler]
+  options[:timeout]   - set a custom timeout for a given RequestLog log operation
+  options[:only_path] - specify a regexp to whitelist REQUEST_PATHs
+  options[:skip_path] - specify a regexp to blacklist REQUEST_PATHs
 
 == Accessing the logs
 

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -22,7 +22,7 @@ describe RequestLog::Middleware do
       @rack_response = [200, {"Content-Type" => "text/html"}, "Hello, World!"]
       @app = lambda { |env| @rack_response }
       @middleware = RequestLog::Middleware.new(@app)
-      @middleware.call(@env).should == @rack_response      
+      @middleware.call(@env).should == @rack_response
     end
 
     it "never calls logger if response content type doesn't match only_path option" do
@@ -32,8 +32,20 @@ describe RequestLog::Middleware do
       @profiler = mock('profiler')
       @profiler.expects(:call).never
       @rack_response = [200, {"Content-Type" => "text/html"}, "Hello, World!"]
-      @app = lambda { |env| @rack_response }      
+      @app = lambda { |env| @rack_response }
       @middleware = RequestLog::Middleware.new(@app, :logger => @logger, :profiler => @profiler, :only_path => %r{\A/v\d})
+      @middleware.call(@env).should == @rack_response
+    end
+
+    it "never calls logger if response content type matches skip_path option" do
+      @env = {"REQUEST_PATH" => "/v1/foobar", "HTTP_USER_AGENT" => "Mozilla/5.0"}
+      @logger = mock('logger')
+      @logger.expects(:call).never
+      @profiler = mock('profiler')
+      @profiler.expects(:call).never
+      @rack_response = [200, {"Content-Type" => "text/html"}, "Hello, World!"]
+      @app = lambda { |env| @rack_response }
+      @middleware = RequestLog::Middleware.new(@app, :logger => @logger, :profiler => @profiler, :skip_path => %r{\A/v\d})
       @middleware.call(@env).should == @rack_response
     end
 
@@ -44,7 +56,7 @@ describe RequestLog::Middleware do
     it "invokes the logger with the data and the profiler if Timeout::Error is raised" do
       call_middleware_with_exception(Timeout::Error)
     end
-    
+
     def call_middleware_with_exception(exception_class)
       @env = {"REQUEST_PATH" => "/", "HTTP_USER_AGENT" => "Mozilla/5.0"}
       @logger = mock('logger')
@@ -55,11 +67,11 @@ describe RequestLog::Middleware do
       @app = lambda { |env| @rack_response }
       $stderr.expects(:puts).with() { |error_string| error_string =~ /#{exception_class.name}/ }
       @middleware = RequestLog::Middleware.new(@app, :logger => @logger, :profiler => @profiler)
-      @middleware.call(@env).should == @rack_response            
+      @middleware.call(@env).should == @rack_response
     end
   end
 
   def env
     {"GATEWAY_INTERFACE"=>"CGI/1.1", "QUERY_STRING"=>"", "REMOTE_ADDR"=>"127.0.0.1", "REMOTE_HOST"=>"www.publish.newsdesk.local", "REQUEST_METHOD"=>"GET", "REQUEST_URI"=>"http://publish.lvh.me:3000/images/logo.png", "SCRIPT_NAME"=>"", "SERVER_NAME"=>"publish.lvh.me", "SERVER_PORT"=>"3000", "SERVER_PROTOCOL"=>"HTTP/1.1", "SERVER_SOFTWARE"=>"WEBrick/1.3.1 (Ruby/1.9.2/2010-08-18)", "HTTP_HOST"=>"publish.lvh.me:3000", "HTTP_USER_AGENT"=>"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2", "HTTP_ACCEPT"=>"image/png,image/*;q=0.8,*/*;q=0.5", "HTTP_ACCEPT_LANGUAGE"=>"en-us,en;q=0.5", "HTTP_ACCEPT_ENCODING"=>"gzip,deflate", "HTTP_ACCEPT_CHARSET"=>"ISO-8859-1,utf-8;q=0.7,*;q=0.7", "HTTP_KEEP_ALIVE"=>"115", "HTTP_CONNECTION"=>"keep-alive", "HTTP_REFERER"=>"http://publish.lvh.me:3000/system/profiling", "HTTP_AUTHORIZATION"=>"Basic YWRtaW46aWx3d3NwYTIwMTA=", "rack.version"=>[1, 1], "rack.input"=>StringIO.new, "rack.errors"=>$stderr, "rack.multithread"=>true, "rack.multiprocess"=>false, "rack.run_once"=>false, "rack.url_scheme"=>"http", "HTTP_VERSION"=>"HTTP/1.1", "REQUEST_PATH"=>"/"}
-  end  
+  end
 end


### PR DESCRIPTION
AFAICT, there's currently only a whitelist option via only_path - I wanted a blacklist option as well. Let me know if there's another way you'd prefer I go about it!
